### PR TITLE
Allow iframe to take 100% width

### DIFF
--- a/static/css/main.css
+++ b/static/css/main.css
@@ -65,6 +65,9 @@ body {
   line-height: 1.6;
   text-rendering: optimizeLegibility !important;
 }
+iframe {
+  width: 100%;
+}
 @media (min-width: 600px) {
   body {
     -webkit-justify-content: center;


### PR DESCRIPTION
This makes the container not overflow in smaller screens.

Screenshots:

![image](https://user-images.githubusercontent.com/649249/44505168-b80b1d80-a654-11e8-80b0-d5ddb55ceb60.png)

<img width="1438" alt="screen shot 2018-08-22 at 9 46 47 pm" src="https://user-images.githubusercontent.com/649249/44505272-4384ae80-a655-11e8-8ebe-e77e82352857.png">
